### PR TITLE
Fix stalling intermedia zygote process during service stop

### DIFF
--- a/zygote/master.py
+++ b/zygote/master.py
@@ -129,8 +129,6 @@ class ZygoteMaster(object):
         # point self.really_stop() will be called
         log.debug('setting self.stopped')
         self.stopped = True
-        if getattr(self, 'io_loop', None) is not None:
-            self.io_loop.stop()
 
     def really_stop(self, status=0):
         sys.exit(status)


### PR DESCRIPTION
When I issue a service stop, the intermediate zygote will not be killed.  I went back to commit hash that first introduce the behavior: fbf38d6adad3a6e223fee003ef47525515413bb8.  I tracked down to the explicit io_loop.stop() that triggers this behavior.

I am not 100% sure why this fixes the intermediate zygote not being killed....
