### PR TITLE
Fix for issues #13 and #36

### DIFF
--- a/zygote/master.py
+++ b/zygote/master.py
@@ -232,7 +232,7 @@ class ZygoteMaster(object):
             else:
                 if zygote == self.current_zygote:
                     self.current_zygote.request_spawn()
-                elif zygote == self.prev_zygote:
+                elif self.current_zygote.canary and zygote == self.prev_zygote:
                     self.prev_zygote.request_spawn()
                 else:
                     # Not a zygote that we care about.


### PR DESCRIPTION
request a new worker spawn on current zygote only if the failed worker is from the current zygote. This fixes #13.

also collect empty zygotes when transitioning idle workers. fixes #36
