### PR TITLE
fix for #16

### DIFF
--- a/zygote/accounting.py
+++ b/zygote/accounting.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 import os
 import signal
 import time
@@ -8,7 +7,7 @@ import zygote.util
 from zygote import message
 from zygote.util import meminfo_fmt
 
-log = logging.getLogger('zygote.accounting')
+log = zygote.util.get_logger('zygote.accounting')
 
 def format_millis(v):
     if v is not None:


### PR DESCRIPTION
This doesn't cause logging to deadlock master/worker but in rare cases logs from master & worker can get merged into a single line.

[9645] 2012-10-12 12:13:50,454 :: DEBUG   :: zygote.util - killing 10957
[9645] 2012-10-12 12:13:50,454 :: DEBUG   :: zygote.master - killing worker 10959 with signal 3[10977] 2012-10-12 12:13:50,454 :: INFO    :: zygote.worker.zygote_process - recieved SIGQUIT (clean exit), exiting

[9645] 2012-10-12 12:13:50,468 :: INFO    :: zygote.master - zygote 11014 exited with status 0

Happens very rarely but I'll create another bug for this issue.
