### PR TITLE
Adds name and versions on the commandline.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,2 +1,5 @@
+0.2 Wed Jan  2 10:38:23 PST 2013
+	* Add a --name/-n option to set proctitle name (eskil@eskil.org).
+
 0.1 Wed Nov 14 11:50:44 PST 2012
-   * Starting a ChangeLog file (eskil@yelp.com)
+	* Starting a ChangeLog file (eskil@yelp.com)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name         = 'zygote',
-    version      = '0.1',
+    version      = '0.2',
     author       = 'Evan Klitzke',
     author_email = 'evan@eklitzke.org',
     description  = 'A tornado HTTP worker management tool',

--- a/zygote/main.py
+++ b/zygote/main.py
@@ -27,6 +27,8 @@ def main():
     parser.add_option('-b', '--basepath', default=os.environ.get('BASEPATH', ''), help='The basepath to use')
     parser.add_option('--control-port', type='int', default=5100, help='The control port to listen on')
     parser.add_option('-d', '--debug', default=False, action='store_true', help='Enable debugging')
+    parser.add_option('-n', '--name', default=None, help='The name of the application to set in proctitle, otherwise use the app module.')
+    parser.add_option('--version', default=None, help='The version of the application to set in proctitle.')
     parser.add_option('-m', '--module', default=None, help='The name of the module holding get_application()')
     parser.add_option('-p', '--port', type='int', default=0, help='The port to bind on')
     parser.add_option('-i', '--interface', default='', help='The interface to bind on')

--- a/zygote/master.py
+++ b/zygote/master.py
@@ -50,6 +50,8 @@ class ZygoteMaster(object):
         sock,
         basepath,
         module,
+        name,
+        version,
         num_workers,
         control_port,
         control_socket_path,
@@ -68,6 +70,8 @@ class ZygoteMaster(object):
         self.sock = sock
         self.basepath = basepath
         self.module = module
+        self.name = name
+        self.version = version
         self.num_workers = num_workers
         self.control_port = control_port
         self.control_socket_path = control_socket_path
@@ -419,6 +423,8 @@ class ZygoteMaster(object):
                     sock=self.sock,
                     basepath=realbase,
                     module=self.module,
+                    name=self.name,
+                    version=self.version,
                     args=self.application_args,
                     ssl_options=self.ssl_options,
                     canary=canary,
@@ -433,9 +439,9 @@ class ZygoteMaster(object):
         self.io_loop.start()
 
 def main(opts, extra_args):
-    setproctitle('zygote master %s' % (opts.module,))
+    setproctitle('zygote master %s' % (opts.name or opts.module,))
     zygote_logger = get_logger('zygote', opts.debug)
-    
+
     if not logging.root.handlers:
         # XXX: WARNING
         #
@@ -486,6 +492,8 @@ def main(opts, extra_args):
         sock,
         basepath=opts.basepath,
         module=opts.module,
+        name=opts.name or opts.module,
+        version=opts.version,
         num_workers=opts.num_workers,
         control_port=opts.control_port,
         control_socket_path=opts.control_socket_path,


### PR DESCRIPTION
The name and version are used to display proctitles. If name is
omitted, the module name is used to be backwards compatible.

If version is omitted, the last part of basepath is used to be
backwards compatible.
