### PR TITLE
addsitedir at zygote initialization

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2013-05-24  Baris Metin  <bmetin@yelp.com>
+
+	* Add load .pth files from basepath at zygote initialization time
+	* Bump version to 0.5
+
 2013-05-09  Baris Metin  <bmetin@yelp.com>
 
 	* Merge David Selassie's install-ioloop branch (worker installs its ioloop as the global ioloop)

--- a/zygote/__init__.py
+++ b/zygote/__init__.py
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"


### PR DESCRIPTION
We should do this at zygote initialization time to have the correct paths at new code reload.
