### PR TITLE
Patch repr of HTTPRequest to not show body or sensitive HTTP headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 	rm -rf tmp_* current
 
 test:
-	@testify -v tests.test
+	@testify -v tests
 
 production:
 

--- a/tests/httpserver_test.py
+++ b/tests/httpserver_test.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import testify as T
+
+from zygote._httpserver import HTTPRequest as HTTPRequest_1
+from zygote._httpserver_2 import HTTPRequest as HTTPRequest_2
+
+
+class HTTPRequestReprTest(T.TestCase):
+
+    def test_http_request_repr_does_not_show_body_or_auth_headers(self):
+        self._verify_safe_repr(HTTPRequest_1)
+
+    def test_http_request_2_repr_does_not_show_body_or_auth_headers(self):
+        self._verify_safe_repr(HTTPRequest_2)
+
+    def _verify_safe_repr(self, http_request_cls):
+        request = http_request_cls(
+            'POST', '/path',
+            version='HTTP/1.1',
+            remote_ip='127.0.0.1',
+            host='127.0.0.1',
+            protocol='http',
+            body='sensitive post information',
+            headers={'Authorization': 'Basic credentials'})
+
+        T.assert_equal(repr(request),
+            "HTTPRequest(protocol='http', host='127.0.0.1', method='POST', uri='/path', version='HTTP/1.1', remote_ip='127.0.0.1', headers={'Authorization': '***redacted***'})")
+
+
+if __name__ == '__main__':
+    T.run()

--- a/zygote/_httpserver.py
+++ b/zygote/_httpserver.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
 ###### THIS IS A MODIFIED VERSION OF TORNADO'S HTTPSERVER FROM TORNADO 1.2 #######
 #
 # It has been modified to support a callback after headers finish, and
 # another callback on close.
+#
+# HTTPRequest.__repr__ has also been modified to not show body (POST can
+# contain sensitive data) or sensitive headers, since HTTPRequest is repr'ed
+# when tornado logs errors.
 #
 # These changes will most likely need to be ported to a new version if you
 # ever want to upgrade tornado.
@@ -35,6 +40,9 @@ from tornado import httputil
 from tornado import ioloop
 from tornado import iostream
 from tornado import stack_context
+
+from zygote.util import sanitize_headers
+
 
 try:
     import fcntl
@@ -543,8 +551,7 @@ class HTTPRequest(object):
             return None
 
     def __repr__(self):
-        attrs = ("protocol", "host", "method", "uri", "version", "remote_ip",
-                 "body")
+        attrs = ("protocol", "host", "method", "uri", "version", "remote_ip")
         args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])
         return "%s(%s, headers=%s)" % (
-            self.__class__.__name__, args, dict(self.headers))
+            self.__class__.__name__, args, sanitize_headers(self.headers))

--- a/zygote/util.py
+++ b/zygote/util.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import with_statement
 
 import errno
@@ -331,3 +332,12 @@ def get_logger(logger_name, debug=False):
         logger.handlers = [NullHandler()]
     return logger
 
+
+def sanitize_headers(headers):
+    """Sanitize sensitive request headers for logging"""
+    results = dict(headers)
+    # Redact instead of remove Authorization header so that those
+    # using Basic Auth can debug if needed
+    if results.get('Authorization'):
+        results['Authorization'] = '***redacted***'
+    return results


### PR DESCRIPTION
On stack traces, Tornado will log the repr of the HTTPRequest object
which had included POST body and if present, header for HTTP Basic
Auth. Both of these can potentially leak sensitive info into logs.

aside: It is ridiculous that this project inlines copies of two
different versions of Tornado yet also requires the Tornado package
to be installed.
