### PR TITLE
Make the logger *not* suppress output just because there is no TTY

### DIFF
--- a/zygote/util.py
+++ b/zygote/util.py
@@ -321,15 +321,12 @@ class LocklessHandler(logging.StreamHandler):
 
 def get_logger(logger_name, debug=False):
     logger = logging.getLogger(logger_name)
-    if os.isatty(sys.stderr.fileno()):
-        formatter = logging.Formatter('[%(process)d] %(asctime)s :: %(levelname)-7s :: %(name)s - %(message)s')
-        handler = LocklessHandler()
-        handler.setFormatter(formatter)
-        handler.setLevel(logging.DEBUG if debug else logging.INFO)
-        logger.handlers = [handler]
-        logger.propagate = False
-    else:
-        logger.handlers = [NullHandler()]
+    formatter = logging.Formatter('[%(process)d] %(asctime)s :: %(levelname)-7s :: %(name)s - %(message)s')
+    handler = LocklessHandler()
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG if debug else logging.INFO)
+    logger.handlers = [handler]
+    logger.propagate = False
     return logger
 
 


### PR DESCRIPTION
I think that detecting the absence of a tty and suppressing all output is surprising.

What if you are running under systemd or upstart and you want to redirect stder/out? What if you are in docker? What if you are running it in jenkins?

Plenty of things don't have a tty but that doesn't mean you don't want a logger.

(internal yelp ticket PAASTA-844) cc @EvanKrall @mrtyler 
